### PR TITLE
Convert to Python 3, fix to work with latest changes to Internet Archive Advanced Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.pyc
 dist/
 locale
+/.project
+/.pydevproject

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -87,6 +87,7 @@ class BooksToolbar(Gtk.Toolbar):
         self.format_combo = ComboBox()
         self.format_combo.connect('changed', self.format_changed_cb)
         self.format_combo.append_item('.pdf', 'PDF')
+        self.format_combo.append_item('.epub', 'EPUB')
         self.format_combo.append_item('.djvu', 'DJVU')
         self.format_combo.set_active(0)
         self.format_combo.props.sensitive = False
@@ -274,6 +275,7 @@ class GetIABooksActivity(activity.Activity):
         self.format_combo = ComboBox()
         self.format_combo.connect('changed', self.format_changed_cb)
         self.format_combo.append_item('.pdf', 'PDF')
+        self.format_combo.append_item('.epub', 'EPUB')
         self.format_combo.append_item('.djvu', 'DJVU')
         self.format_combo.set_active(0)
         self.format_combo.props.sensitive = False

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -2,9 +2,9 @@
 name = Get IA Books
 bundle_id = org.laptop.sugar.GetIABooksActivity
 icon = get-ia-books
-exec = sugar-activity GetIABooksActivity.GetIABooksActivity
+exec = sugar-activity3 GetIABooksActivity.GetIABooksActivity
 show_launcher = yes
-activity_version = 8
+activity_version = 9
 license = GPLv2+
 summary = Download thousands of free e-books in PDF, DejaVu, and EPUB formats from the Internet Archive!
 repository = https://github.com/sugarlabs/getiabooks.git


### PR DESCRIPTION
Minor changes for Python 3, change query format for Internet Archive Advanced Search. Also I no longer make DJVU the default format because archive.org has stopped creating it for every book. It is still possible to download DJVUs and EPUBs but they won't always be available.